### PR TITLE
cv_cameraにparamを追加。Jetsoni上でUSBカメラを使用するように設定。

### DIFF
--- a/launch/robot_lab.launch
+++ b/launch/robot_lab.launch
@@ -12,6 +12,7 @@
     <param name="rate" value="10.0"/>
     <param name="image_width" value="640"/>
     <param name="image_height" value="480"/>
+    <param name="device_id" value="1"/>
   </node>
   <node name="mjpeg_server" pkg="mjpeg_server" type="mjpeg_server">
     <param name="port" value="10000"/>


### PR DESCRIPTION
Jetson上でUSBカメラを使用するためにdevice_idを1に指定しました。